### PR TITLE
2.5 configuration

### DIFF
--- a/repo/packages/A/aqua-agent/0/config.json
+++ b/repo/packages/A/aqua-agent/0/config.json
@@ -58,11 +58,6 @@
           "description": "Whether the Aqua agent should restart the existing Docker containers.",
           "type": "boolean",
           "default": false
-        },
-        "container_mode": {
-          "description": "Run as a container with no docker restart? (experimental)",
-          "type": "boolean",
-          "default": true
         }
       },
       "required":[
@@ -77,7 +72,7 @@
         "image_name": {
           "description": "Image name to use",
           "type": "string",
-          "default": "aquasec/agent:2.1.5"
+          "default": "aquasec/agent:2.5.rc"
         },
         "always_pull_image": {
           "description": "Always attempt to pull image before deploying",

--- a/repo/packages/A/aqua-agent/0/config.json
+++ b/repo/packages/A/aqua-agent/0/config.json
@@ -72,7 +72,7 @@
         "image_name": {
           "description": "Image name to use",
           "type": "string",
-          "default": "aquasec/agent:2.5.rc"
+          "default": "aquasec/agent:2.5"
         },
         "always_pull_image": {
           "description": "Always attempt to pull image before deploying",

--- a/repo/packages/A/aqua-agent/0/marathon.json.mustache
+++ b/repo/packages/A/aqua-agent/0/marathon.json.mustache
@@ -15,20 +15,15 @@
     ["hostname", "UNIQUE"]
   ],
   "env": {
-    "SCALOCK_SERVER": "{{aqua_config.gateway_address}}",
-    "SILENT": "yes",
+    "AQUA_SERVER": "{{aqua_config.gateway_address}}",
     "AQUA_TOKEN": "{{aqua_config.aqua_token}}",
-    "AQUA_RUN_WATCHER": "yes",
-    {{#aqua_config.container_mode}}
-        "AQUA_MODE": "CONTAINER",
-    {{/aqua_config.container_mode}}
     {{#aqua_config.restart_containers}}
         "RESTART_CONTAINERS": "yes",
     {{/aqua_config.restart_containers}}
     {{^aqua_config.restart_containers}}
       "RESTART_CONTAINERS": "no",
       {{/aqua_config.restart_containers}}
-    "SCALOCK_IMAGE": "{{docker.image_name}}"
+    "SILENT": "yes"
   },
   "labels": {
     "AGENT_FILL": "true"
@@ -57,7 +52,35 @@
         {{/docker.namespaces_enabled}}
         {
           "key": "volume",
-          "value": "/var/run/docker.sock:/var/run/docker.sock"
+          "value": "/var/run:/var/run"
+        },
+        {
+          "key": "volume",
+          "value": "/dev:/dev"
+        },
+        {
+          "key": "volume",
+          "value": "/opt/aquasec:/host/opt/aquasec:ro"
+        },
+        {
+          "key": "volume",
+          "value": "/opt/aquasec/tmp:/opt/aquasec/tmp"
+        },
+        {
+          "key": "volume",
+          "value": "/opt/aquasec/audit:/opt/aquasec/audit"
+        },
+        {
+          "key": "volume",
+          "value": "/proc:/host/proc:ro"
+        },
+        {
+          "key": "volume",
+          "value": "/sys:/host/sys:ro"
+        },
+        {
+          "key": "volume",
+          "value": "/etc:/host/etc:ro"
         },
         {
           "key": "env",
@@ -66,6 +89,10 @@
         {
           "key": "user",
           "value": "root"
+        },
+        {
+          "key": "pid",
+          "value": "host"
         }
       ]
     }

--- a/repo/packages/A/aqua-agent/0/marathon.json.mustache
+++ b/repo/packages/A/aqua-agent/0/marathon.json.mustache
@@ -93,6 +93,10 @@
         {
           "key": "pid",
           "value": "host"
+        },
+        {
+          "key": "rm",
+          "value": "true"
         }
       ]
     }

--- a/repo/packages/A/aqua-agent/0/package.json
+++ b/repo/packages/A/aqua-agent/0/package.json
@@ -13,6 +13,6 @@
     "security"
   ],
   "selected": true,
-  "version": "2.1.5",
+  "version": "2.5",
   "website": "https://www.aquasec.com/"
 }

--- a/repo/packages/A/aqua-agent/0/resource.json
+++ b/repo/packages/A/aqua-agent/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "agent": "aquasec/agent:2.5.rc"
+        "agent": "aquasec/agent:2.5"
       }
     }
   }

--- a/repo/packages/A/aqua-agent/0/resource.json
+++ b/repo/packages/A/aqua-agent/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "agent": "aquasec/agent:2.1.5.rc"
+        "agent": "aquasec/agent:2.5.rc"
       }
     }
   }

--- a/repo/packages/A/aqua-agent/0/resource.json
+++ b/repo/packages/A/aqua-agent/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "agent": "aquasec/agent:2.1.5"
+        "agent": "aquasec/agent:2.1.5.rc"
       }
     }
   }

--- a/repo/packages/A/aqua-gateway/0/config.json
+++ b/repo/packages/A/aqua-gateway/0/config.json
@@ -150,7 +150,7 @@
         "image_name": {
           "description": "Image name to use",
           "type": "string",
-          "default": "aquasec/gateway:2.5.rc"
+          "default": "aquasec/gateway:2.5"
         },
         "always_pull_image": {
           "description": "Always attempt to pull image before deploying",

--- a/repo/packages/A/aqua-gateway/0/config.json
+++ b/repo/packages/A/aqua-gateway/0/config.json
@@ -130,6 +130,11 @@
           "description": "Accepted resource role restriction for service",
           "type": "string",
           "default": "*"
+        },
+        "log_level": {
+          "description": "Log verbosity level",
+          "type": "string",
+          "default": "DEBUG"
         }
       },
       "required": [
@@ -145,7 +150,7 @@
         "image_name": {
           "description": "Image name to use",
           "type": "string",
-          "default": "aquasec/gateway:2.1.5"
+          "default": "aquasec/gateway:2.5.rc"
         },
         "always_pull_image": {
           "description": "Always attempt to pull image before deploying",

--- a/repo/packages/A/aqua-gateway/0/marathon.json.mustache
+++ b/repo/packages/A/aqua-gateway/0/marathon.json.mustache
@@ -31,7 +31,7 @@
     "SCALOCK_GATEWAY_PUBLIC_IP": "{{service.public_address}}",
     "SCALOCK_GATEWAY_PRIVATE_IP": "$LIBPROCESS_IP",
     "HEALTH_MONITOR": "0.0.0.0:80",
-    "SCALOCK_LOG_LEVEL": "DEBUG"
+    "SCALOCK_LOG_LEVEL": "{{advanced.log_level}}"
   },
   "container": {
     "type": "DOCKER",

--- a/repo/packages/A/aqua-gateway/0/package.json
+++ b/repo/packages/A/aqua-gateway/0/package.json
@@ -12,7 +12,7 @@
     "aqua",
     "security"
   ],
-  "version": "2.1.5",
+  "version": "2.5",
   "website": "https://www.aquasec.com/",
   "selected": true
 }

--- a/repo/packages/A/aqua-gateway/0/resource.json
+++ b/repo/packages/A/aqua-gateway/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "gateway": "aquasec/gateway:2.1.5.rc"
+        "gateway": "aquasec/gateway:2.5.rc"
       }
     }
   }

--- a/repo/packages/A/aqua-gateway/0/resource.json
+++ b/repo/packages/A/aqua-gateway/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "gateway": "aquasec/gateway:2.1.5"
+        "gateway": "aquasec/gateway:2.1.5.rc"
       }
     }
   }

--- a/repo/packages/A/aqua-gateway/0/resource.json
+++ b/repo/packages/A/aqua-gateway/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "gateway": "aquasec/gateway:2.5.rc"
+        "gateway": "aquasec/gateway:2.5"
       }
     }
   }

--- a/repo/packages/A/aqua-scanner/0/config.json
+++ b/repo/packages/A/aqua-scanner/0/config.json
@@ -85,7 +85,7 @@
         "image_name": {
           "description": "Image name to use",
           "type": "string",
-          "default": "aquasec/scanner-cli:2.5.rc"
+          "default": "aquasec/scanner-cli:2.5"
         },
         "always_pull_image": {
           "description": "Always attempt to pull image before deploying",

--- a/repo/packages/A/aqua-scanner/0/config.json
+++ b/repo/packages/A/aqua-scanner/0/config.json
@@ -65,6 +65,11 @@
           "description": "Accepted resource role restriction for service",
           "type": "string",
           "default": "*"
+        },
+        "log_level": {
+          "description": "Log level",
+          "type": "string",
+          "default": "DEBUG"
         }
       },
       "required": [
@@ -80,7 +85,7 @@
         "image_name": {
           "description": "Image name to use",
           "type": "string",
-          "default": "aquasec/scanner-cli:2.1.5"
+          "default": "aquasec/scanner-cli:2.5.rc"
         },
         "always_pull_image": {
           "description": "Always attempt to pull image before deploying",

--- a/repo/packages/A/aqua-scanner/0/config.json
+++ b/repo/packages/A/aqua-scanner/0/config.json
@@ -36,7 +36,7 @@
         "aqua_host": {
           "description": "Web address for aqua-web",
           "type": "string",
-          "default": "http://aqua-web.marathon.l4lb.thisdcos.directory:8084"
+          "default": "http://aqua-web.marathon.l4lb.thisdcos.directory:8080"
         }
       },
       "required": [

--- a/repo/packages/A/aqua-scanner/0/marathon.json.mustache
+++ b/repo/packages/A/aqua-scanner/0/marathon.json.mustache
@@ -14,7 +14,7 @@
   "constraints": [
   ],
   "env": {
-    "SCALOCK_LOG_LEVEL": "DEBUG"
+      "SCALOCK_LOG_LEVEL": "{{advanced.log_level}}"
   },
   "container": {
     "type": "DOCKER",

--- a/repo/packages/A/aqua-scanner/0/package.json
+++ b/repo/packages/A/aqua-scanner/0/package.json
@@ -12,7 +12,7 @@
     "aqua",
     "security"
   ],
-  "version": "2.1.5",
+  "version": "2.5",
   "website": "https://www.aquasec.com/",
   "selected": true
 }

--- a/repo/packages/A/aqua-scanner/0/resource.json
+++ b/repo/packages/A/aqua-scanner/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "gateway": "aquasec/scanner-cli:2.1.5"
+        "gateway": "aquasec/scanner-cli:2.5.rc"
       }
     }
   }

--- a/repo/packages/A/aqua-scanner/0/resource.json
+++ b/repo/packages/A/aqua-scanner/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "gateway": "aquasec/scanner-cli:2.5.rc"
+        "gateway": "aquasec/scanner-cli:2.5"
       }
     }
   }

--- a/repo/packages/A/aqua-server/0/config.json
+++ b/repo/packages/A/aqua-server/0/config.json
@@ -175,7 +175,7 @@
         "image_name": {
           "description": "Image name to use",
           "type": "string",
-          "default": "aquasec/server:2.1.5"
+          "default": "aquasec/server:2.5.rc"
         },
         "always_pull_image": {
           "description": "Always attempt to pull image before deploying",

--- a/repo/packages/A/aqua-server/0/config.json
+++ b/repo/packages/A/aqua-server/0/config.json
@@ -175,7 +175,7 @@
         "image_name": {
           "description": "Image name to use",
           "type": "string",
-          "default": "aquasec/server:2.5.rc"
+          "default": "aquasec/server:2.5"
         },
         "always_pull_image": {
           "description": "Always attempt to pull image before deploying",

--- a/repo/packages/A/aqua-server/0/package.json
+++ b/repo/packages/A/aqua-server/0/package.json
@@ -11,7 +11,7 @@
     "aqua",
     "security"
   ],
-  "version": "2.1.5",
+  "version": "2.5",
   "website": "https://www.aquasec.com/",
   "selected": true
 }

--- a/repo/packages/A/aqua-server/0/resource.json
+++ b/repo/packages/A/aqua-server/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "server": "aquasec/server:2.5.rc"
+        "server": "aquasec/server:2.5"
       }
     }
   }

--- a/repo/packages/A/aqua-server/0/resource.json
+++ b/repo/packages/A/aqua-server/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "server": "aquasec/server:2.1.5"
+        "server": "aquasec/server:2.5.rc"
       }
     }
   }


### PR DESCRIPTION
The 2.5 release changes the way the agent is deployed.  There is a service mode deployment, in which the agent runs directly in container launched via marathon instead of using a watcher service.  When this container is gone, the agent is no longer enforcing.  In previous release the enforcer would still run in background, and future watchers would not update it.  Removal had to be done manually or via undeploy container to trigger uninstall.  Previous mode can still be used, to ensure agent is still in place after watcher is removed, but is no longer default behavior.  For previous method simply update image names in 2.1.5 release tag.